### PR TITLE
ENG-2653: Examples for Manager Approvals For Approval Workflows

### DIFF
--- a/7_managing_approval_workflows/list_approval_workflow.py
+++ b/7_managing_approval_workflows/list_approval_workflow.py
@@ -65,6 +65,8 @@ approval_workflow = strongdm.ApprovalWorkflow(
         strongdm.ApprovalFlowStep(
             approvers=[
                 strongdm.ApprovalFlowApprover(account_id=account2_id),
+                strongdm.ApprovalFlowApprover(reference=strongdm.ApprovalFlowApprover.MANAGER_OF_REQUESTER),
+                strongdm.ApprovalFlowApprover(reference=strongdm.ApprovalFlowApprover.MANAGER_OF_MANAGER_OF_REQUESTER),
             ],
             quantifier="any",
             skip_after=timedelta(hours=1)

--- a/7_managing_approval_workflows/list_approval_workflow.py
+++ b/7_managing_approval_workflows/list_approval_workflow.py
@@ -65,8 +65,8 @@ approval_workflow = strongdm.ApprovalWorkflow(
         strongdm.ApprovalFlowStep(
             approvers=[
                 strongdm.ApprovalFlowApprover(account_id=account2_id),
-                strongdm.ApprovalFlowApprover(reference=strongdm.ApprovalFlowApprover.MANAGER_OF_REQUESTER),
-                strongdm.ApprovalFlowApprover(reference=strongdm.ApprovalFlowApprover.MANAGER_OF_MANAGER_OF_REQUESTER),
+                strongdm.ApprovalFlowApprover(reference=strongdm.ApproverReference.MANAGER_OF_REQUESTER),
+                strongdm.ApprovalFlowApprover(reference=strongdm.ApproverReference.MANAGER_OF_MANAGER_OF_REQUESTER),
             ],
             quantifier="any",
             skip_after=timedelta(hours=1)

--- a/7_managing_approval_workflows/manual_approval_workflow.py
+++ b/7_managing_approval_workflows/manual_approval_workflow.py
@@ -65,7 +65,7 @@ approval_workflow = strongdm.ApprovalWorkflow(
         strongdm.ApprovalFlowStep(
             approvers=[
                 strongdm.ApprovalFlowApprover(account_id=account2_id),
-                strongdm.ApprovalFlowApprover(reference=strongdm.ApprovalFlowApprover.MANAGER_OF_REQUESTER),
+                strongdm.ApprovalFlowApprover(reference=strongdm.ApproverReference.MANAGER_OF_REQUESTER),
             ],
             quantifier="any",
             skip_after=timedelta(hours=1)
@@ -115,7 +115,7 @@ updated_approval_workflow = strongdm.ApprovalWorkflow(
         strongdm.ApprovalFlowStep(
             approvers=[
                 strongdm.ApprovalFlowApprover(account_id=account2_id),
-                strongdm.ApprovalFlowApprover(reference=strongdm.ApprovalFlowApprover.MANAGER_OF_MANAGER_OF_REQUESTER),
+                strongdm.ApprovalFlowApprover(reference=strongdm.ApproverReference.MANAGER_OF_MANAGER_OF_REQUESTER),
             ],
             quantifier="any",
             skip_after=timedelta(hours=3)

--- a/7_managing_approval_workflows/manual_approval_workflow.py
+++ b/7_managing_approval_workflows/manual_approval_workflow.py
@@ -65,6 +65,7 @@ approval_workflow = strongdm.ApprovalWorkflow(
         strongdm.ApprovalFlowStep(
             approvers=[
                 strongdm.ApprovalFlowApprover(account_id=account2_id),
+                strongdm.ApprovalFlowApprover(reference=strongdm.ApprovalFlowApprover.MANAGER_OF_REQUESTER),
             ],
             quantifier="any",
             skip_after=timedelta(hours=1)
@@ -114,6 +115,7 @@ updated_approval_workflow = strongdm.ApprovalWorkflow(
         strongdm.ApprovalFlowStep(
             approvers=[
                 strongdm.ApprovalFlowApprover(account_id=account2_id),
+                strongdm.ApprovalFlowApprover(reference=strongdm.ApprovalFlowApprover.MANAGER_OF_MANAGER_OF_REQUESTER),
             ],
             quantifier="any",
             skip_after=timedelta(hours=3)


### PR DESCRIPTION
Addresses ENG-2653

We introduce the ability to specify the "manager-of-requester" or "manager-of-manager-of-requester" as an approver for approval workflows and update the examples to reflect that.

## QA

Validated examples run on local system.  