### PR TITLE
ENG-5861: update python sdk to include some bind_interface usage examples

### DIFF
--- a/1_managing_resources/create_datasource.py
+++ b/1_managing_resources/create_datasource.py
@@ -23,7 +23,6 @@ api_access_key = os.getenv("SDM_API_ACCESS_KEY")
 api_secret_key = os.getenv("SDM_API_SECRET_KEY")
 client = strongdm.Client(api_access_key, api_secret_key)
 
-# Set `port_override` to `-1` to auto-generate a port if Port Overrides is enabled.
 postgres = strongdm.Postgres(
     name="Example Postgres Datasource for Python",
     hostname="example.strongdm.com",
@@ -31,8 +30,33 @@ postgres = strongdm.Postgres(
     username="example",
     password="example",
     database="example",
+    # May be set to one of the ResourceIPAllocationMode constants to select between VNM,
+    # loopback, or default allocation. If not set, will behave as if configured for
+    # 'default'.
+    # For more details on Virtual Networking Mode see documentation here:
+    # https://docs.strongdm.com/admin/clients/client-networking/virtual-networking-mode
+    bind_interface=strongdm.ResourceIPAllocationMode.LOOPBACK,
+    # Set `PortOverride` to `-1` to auto-allocate an available port.
     port_override=19300,
 )
+
+# You can also specify an explicit loopback IP address to bind to if Loopback IP Ranges
+# are enabled as documented here:
+# https://docs.strongdm.com/admin/clients/client-networking/loopback-ip-ranges
+postgres.bind_interface = "127.0.0.2"
+
+# ...Or if your organization has Virtual Networking Mode enabled,
+# you may configure the resource's bind interface
+# to automatically get an IP allocated upon creation:
+postgres.bind_interface = strongdm.ResourceIPAllocationMode.VNM
+
+# ...Or specify an explicit VNM IP address to bind to...
+postgres.bind_interface = "100.64.0.1"
+
+# Your organization can default either to 'loopback' or 'vnm', and
+# ResourceIPAllocationMode.DEFAULT will honor that.
+postgres.bind_interface = strongdm.ResourceIPAllocationMode.DEFAULT
+
 
 response = client.resources.create(postgres, timeout=30)
 

--- a/1_managing_resources/update_resource.py
+++ b/1_managing_resources/update_resource.py
@@ -46,9 +46,26 @@ resource = get_response.resource
 # Update the fields to change
 resource.name = "Example Name Updated for Python"
 
+# If your organization has Virtual Networking Mode enabled,
+# you can automatically allocate an IP to that resource via the ResourceIPAllocationMode.VNM constant...
+resource.bind_interface = strongdm.ResourceIPAllocationMode.VNM
+
+# ...Or fallback to the default behavior for your organization...
+resource.bind_interface = strongdm.ResourceIPAllocationMode.DEFAULT
+
+# ...Or if there is a specific IP to bind to, you can specify it directly.
+# For more details on Virtual Networking Mode see documentation here:
+# https://docs.strongdm.com/admin/clients/client-networking/virtual-networking-mode
+resource.bind_interface = "127.0.0.1"
+
+# Update `port_override` to `-1` to auto-allocate a different available port.
+resource.port_override = -1
+
 # Update the datasource
 update_response = client.resources.update(resource, timeout=30)
 
 print("Successfully updated Postgres datasource.")
 print("\tID:", update_response.resource.id)
 print("\tName:", update_response.resource.name)
+print("\tBindInterface:", update_response.resource.bind_interface)
+print("\tPortOverride:", update_response.resource.port_override)


### PR DESCRIPTION
This PR updates the create and update examples of resources, which showcases how to use the new bindInterface property on resources. Highlighting the constants available in the SDK, the values you can use outside of those constants, as well as links to relevant docs.

### QA

- [x] create_datasource.py
```bash
python3 create_datasource.py
Successfully created Postgres datasource.
        Name: Example Postgres Datasource for Python
        ID: rs-7b98656568e53ecc
```
- [x] update_resource.py
```bash
python3 update_resource.py
Successfully created Postgres datasource.
        Name: Example Postgres Datasource for Update Test
        ID: rs-53546ab768e53ede
Successfully updated Postgres datasource.
        ID: rs-53546ab768e53ede
        Name: Example Name Updated for Python
        BindInterface: 127.0.0.1
        PortOverride: 10009

```